### PR TITLE
fix(resit): dont bombout on errors

### DIFF
--- a/models/container.js
+++ b/models/container.js
@@ -37,6 +37,6 @@ schema.container = {
     required: true,
     test: helpers.isValidDockerLink,
     description: "The docker image tag.",
-    requirement: "must be a valid docker link (formatted docker_image_name:tag)"
+    requirement: "must be a valid docker link (formatted docker-image-name:tag. With no underscores!"
   }
 }

--- a/restit/genEndpointsFromSchema.js
+++ b/restit/genEndpointsFromSchema.js
@@ -435,12 +435,9 @@ module.exports = (schemas, mongoose, config) => {
         details: err
       }));
     } else {
-      if(!o || typeof o.error !== 'undefined') {
-        if (o.error.match(/Container Error.+Specify unique combinations/)) {
-          res.status(409);
-        } else {
-          res.status(422);
-        }
+      console.log(o)
+      if(!o || o.error) {
+        res.status(422);
         res.send(JSON.stringify(o));
       } else {
         res.send(JSON.stringify(documentToObject(o)));


### PR DESCRIPTION
- just throw a 500 for any error
- log the error

It was throwing 

```
TypeError: o.error.match is not a function
    at finisher (/Users/jkurz/turner/argo/mss-indexit-api/restit/genEndpointsFromSchema.js:440:21)
```
