### PR TITLE
Cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+*.test
+*.log

--- a/handlers/requestHandlers.js
+++ b/handlers/requestHandlers.js
@@ -12,25 +12,25 @@ module.exports = function (lm) {
 
         if (cached) {
             console.log('using cached response');
-            res.json(cached);
-        } else {
-            return m.Container.find({}).sort({name: 1}).exec((err, results) => {
-                if (err) {
-                    res.status(500);
-                    return res.json({ error: 'Something went wrong' });
-                }
-
-                let data = results.map((result) => result.name).filter((result, i , results) => results.indexOf(result) === i);
-
-                cached = data;
-                res.json(data);
-            });
+            return res.json(cached);
         }
+
+        return m.Container.find({}).sort({name: 1}).exec((err, results) => {
+            if (err) {
+                res.status(500);
+                return res.json({ error: 'Something went wrong' });
+            }
+
+            let data = results.map((result) => result.name).filter((result, i , results) => results.indexOf(result) === i);
+
+            cached = data;
+            res.json(data);
+        });
     }
 
     e.getContainerVersions = function (req, res) {
         return m.Container.find({ name: req.params.name }).exec((err, container) => {
-            if (err || ! container) {
+            if (err || !container) {
                 res.status(404);
                 return res.json({ error: 'Container not found' });
             }
@@ -42,7 +42,7 @@ module.exports = function (lm) {
 
     e.getContainer = function (req, res) {
         return m.Container.findOne({ name: req.params.name, version: req.params.version }).exec((err, container) => {
-            if (err || ! container) {
+            if (err || !container) {
                 res.status(404);
                 return res.json({ error: 'Container not found' });
             }

--- a/handlers/requestHandlers.js
+++ b/handlers/requestHandlers.js
@@ -1,47 +1,47 @@
-"use strict"
+"use strict";
 
-let documentToObject = require('../restit');
+module.exports = function (lm) {
+    let m = lm,
+        e = {};
 
-module.exports = function(lm) {
+    e.getContainers = function (req, res) {
+        let promises = [];
 
-  let m = lm;
-  let e = {};
+        return m.Container.find({}).sort({name: 1}).exec((err, results) => {
+            if (err) {
+                res.status(500);
+                return res.json({ error: 'Something went wrong' });
+            }
 
-  e.getContainers = function(req, res) {
-    let promises = [];
+            let data = results.map((result) => result.name).filter((result, i , results) => results.indexOf(result) === i);
 
-    return m.Container.find({}).sort({name: 1}).exec(function (err, results) {
-        if(err) {res.status(500);res.send(JSON.stringify({error: 'Something went wrong'})); return};
-        let data = results.map((result) => result.name)
-                          .filter((result, i , results) => results.indexOf(result) === i);
-        res.json(data);
-    });
-  }
+            cached = data;
+            res.json(data);
+        });
+    }
 
-  e.getContainerVersions = function(req, res) {
-      return m.Container.find({name: req.params.name}).exec(function (err, container) {
-        if(err || ! container) {
-          res.status(404);
-          res.send(JSON.stringify({error: 'Container not found'}));
-          return;
-        }
+    e.getContainerVersions = function (req, res) {
+        return m.Container.find({ name: req.params.name }).exec((err, container) => {
+            if (err || ! container) {
+                res.status(404);
+                return res.json({ error: 'Container not found' });
+            }
 
-        let data = container.map((data) => ({version: data.version, name: data.name, image: data.image}));
-        res.json(data);
-      });
-  }
+            let data = container.map((data) => { version: data.version, name: data.name, image: data.image });
+            res.json(data);
+        });
+    }
 
-  e.getContainer = function(req, res) {
-      return m.Container.findOne({name: req.params.name, version: req.params.version}).exec(function (err, container) {
-        if(err || ! container) {
-          res.status(404);
-          res.send(JSON.stringify({error: 'Container not found'}));
-          return;
-        }
+    e.getContainer = function (req, res) {
+        return m.Container.findOne({ name: req.params.name, version: req.params.version }).exec((err, container) => {
+            if (err || ! container) {
+                res.status(404);
+                return res.json({ error: 'Container not found' });
+            }
 
-        res.json({name: container.name, version: container.version, image: container.image});
-      });
-  }
+            res.json({ name: container.name, version: container.version, image: container.image });
+        });
+    }
 
-  return e;
+    return e;
 };


### PR DESCRIPTION
Noticing _**very**_ slow response times from `/v1/containers`. Adding a dead simple cache (non-shared, in-memory). 

Testing mechanism:

+ Created `curl-format.txt` file with the following contents
```
    time_namelookup:  %{time_namelookup}\n
       time_connect:  %{time_connect}\n
    time_appconnect:  %{time_appconnect}\n
   time_pretransfer:  %{time_pretransfer}\n
      time_redirect:  %{time_redirect}\n
 time_starttransfer:  %{time_starttransfer}\n
                    ----------\n
         time_total:  %{time_total}\n
```

+ Ran local instance with production database, and saw this result
```
$ while true; do curl -sSw "@curl-format.txt" -o /dev/null "http://localhost:8080/v1/containers"; echo; done
    time_namelookup:  0.005
       time_connect:  0.005
    time_appconnect:  0.000
   time_pretransfer:  0.005
      time_redirect:  0.000
 time_starttransfer:  5.441
                    ----------
         time_total:  5.441

    time_namelookup:  0.005
       time_connect:  0.005
    time_appconnect:  0.000
   time_pretransfer:  0.005
      time_redirect:  0.000
 time_starttransfer:  6.279
                    ----------
         time_total:  6.279

    time_namelookup:  0.005
       time_connect:  0.005
    time_appconnect:  0.000
   time_pretransfer:  0.005
      time_redirect:  0.000
 time_starttransfer:  6.068
                    ----------
         time_total:  6.068
```

+ Added caching code, reran with these results
```
$ while true; do curl -sSw "@curl-format.txt" -o /dev/null "http://localhost:8080/v1/containers"; echo; done
    time_namelookup:  0.005
       time_connect:  0.005
    time_appconnect:  0.000
   time_pretransfer:  0.005
      time_redirect:  0.000
 time_starttransfer:  5.747
                    ----------
         time_total:  5.747

    time_namelookup:  0.005
       time_connect:  0.005
    time_appconnect:  0.000
   time_pretransfer:  0.005
      time_redirect:  0.000
 time_starttransfer:  0.008
                    ----------
         time_total:  0.008

    time_namelookup:  0.005
       time_connect:  0.005
    time_appconnect:  0.000
   time_pretransfer:  0.005
      time_redirect:  0.000
 time_starttransfer:  0.008
                    ----------
         time_total:  0.008

    time_namelookup:  0.005
       time_connect:  0.005
    time_appconnect:  0.000
   time_pretransfer:  0.005
      time_redirect:  0.000
 time_starttransfer:  0.008
                    ----------
         time_total:  0.008
```

Look at commit d179854 to see just the changes.