### PR TITLE
feature(delete): allow containers to be deleted

### DIFF
--- a/handlers/requestHandlers.js
+++ b/handlers/requestHandlers.js
@@ -16,7 +16,12 @@ module.exports = function (lm) {
     }
 
     e.getContainerVersions = function (req, res) {
-        return m.Container.find({ name: req.params.name }).exec((err, container) => {
+        let opts = { name: req.params.name, active: true };
+        if (typeof req.query.all !== 'undefined') {
+            delete opts.active;
+        }
+
+        return m.Container.find(opts).exec((err, container) => {
             if (err || !container) {
                 res.status(404);
                 return res.json({ error: 'Container not found' });
@@ -34,7 +39,41 @@ module.exports = function (lm) {
                 return res.json({ error: 'Container not found' });
             }
 
-            res.json({ name: container.name, version: container.version, image: container.image });
+            res.json({ name: container.name, version: container.version, image: container.image, active: container.active });
+        });
+    }
+
+    e.addContainer = function (req, res) {
+        return m.Container.findOne({ name: req.params.name, version: req.params.version }).exec((err, container) => {
+            if (err || !container) {
+                res.status(404);
+                return res.json({ error: 'Container not found' });
+            }
+            container.active = true;
+            container.save((err, item) => {
+                if (err) {
+                    return res.json({ error: 'Container not updated.', message: err.message });
+                }
+
+                res.json({ name: item.name, version: item.version, image: item.image, active: item.active });
+            });
+        });
+    }
+
+    e.removeContainer = function (req, res) {
+        return m.Container.findOne({ name: req.params.name, version: req.params.version }).exec((err, container) => {
+            if (err || !container) {
+                res.status(404);
+                return res.json({ error: 'Container not found' });
+            }
+            container.active = false;
+            container.save((err, item) => {
+                if (err) {
+                    return res.json({ error: 'Container not updated.', message: err.message });
+                }
+
+                res.json({ name: item.name, version: item.version, image: item.image, active: item.active });
+            });
         });
     }
 

--- a/models/container.js
+++ b/models/container.js
@@ -40,5 +40,16 @@ schema.container = {
     test: helpers.isValidDockerLink,
     description: "The docker image tag.",
     requirement: "must be a valid docker link (formatted docker-image-name:tag. With no underscores!"
+  },
+  active: {
+    type: Boolean,
+    unique: false,
+    create: true,
+    update: true,
+    required: false,
+    default: true,
+    test: helpers.isBoolean,
+    description: "Wether the name/version pair is active. Inactive means it will not be shown",
+    requirement: "Must be a boolean value."
   }
 }

--- a/server.js
+++ b/server.js
@@ -19,19 +19,31 @@ let allEndpoints = modelEndpoints.concat([
     path:        '/v1/containers',
     type:        'get',
     function:    requestHelper.getContainers,
-    description: 'Returns all container names',
+    description: 'Returns all container names.',
     fields: []
   }, {
     path:        '/v1/container/:name',
     type:        'get',
     function:    requestHelper.getContainerVersions,
-    description: 'Returns a container object with all of its version',
+    description: 'Returns an array of all active containers; use query parameter `all` to see inactive and active containers.',
     fields: []
   }, {
     path:        '/v1/container/:name/:version',
     type:        'get',
     function:    requestHelper.getContainer,
-    description: 'Returns a single container object.',
+    description: 'Returns a single container.',
+    fields: []
+  }, {
+    path:        '/v1/container/:name/:version',
+    type:        'post',
+    function:    requestHelper.addContainer,
+    description: 'Sets a container to active state (must already exist via `POST /v1/containers`).',
+    fields: []
+  }, {
+    path:        '/v1/container/:name/:version',
+    type:        'delete',
+    function:    requestHelper.removeContainer,
+    description: 'Sets a container to inactive state. Will not be shown in default listing of container versions.',
     fields: []
   }
 ]);
@@ -48,7 +60,7 @@ app.all('/v1*', (req, res, next) => {
 
 app.post('/v1/containers', (req, res, next) => {
     if (!req.body.image) {
-        res.status(500).json({"message": "You must provide an image"});
+        res.status(422).json({"message": "You must provide an image."});
         return;
     }
     req.body.image = req.body.image.replace('https://', '').replace('http://', '');


### PR DESCRIPTION
## Primary change(s)

Adds two new endpoints:

+ `DELETE /v1/container/:name/:version` which will "delete" a container by setting the active flag to false.

+ `POST /v1/container/:name/:version` which will "un-delete" a container by setting the active flag to true.

Updates two existing endpoints:

+ `GET /v1/container/:name` now only shows active containers. Adds a query flag (?all), that when used will show active _and_ inactive containers.

+ `GET /v1/container/:name/:version` shows the active status of the container.


## Additional change(s)

+ `POST /v1/containers` Fixed the returned status code when image property is missing; return a 422 instead of a 500.