### PR TITLE
fix(regex): fix backtracking regex

### DIFF
--- a/restit/lib/restHelpers.js
+++ b/restit/lib/restHelpers.js
@@ -10,8 +10,9 @@ e.isString = function(callBack,i) {
 }
 
 e.isValidDockerLink = function(callBack,i) {
-  var regexp = /^([a-zA-Z0-9.-]*)(\/?([a-z0-9.-]{1,63}))+:?([a-zA-Z0-9.-]*)$/
-  callBack(regexp.test(i));
+  var regexp = /^([a-zA-Z0-9.-]*)(\/?([a-z0-9.-]{1,63})){1,2}:?([a-zA-Z0-9.-]+)$/
+  var pass = regexp.test(i);
+  callBack(pass);
 }
 
 e.isValidPort = function(callBack,i) {

--- a/test/index.js
+++ b/test/index.js
@@ -63,4 +63,5 @@ describe('isValidDockerLink', () => {
     it('should return false for invalid links', () => helpers.isValidDockerLink(expectTrue, 'foo-bar:0.1.1'));
     it('should return false for invalid links', () => helpers.isValidDockerLink(expectTrue, 'garbage/foo-bar:0.1.1'));
     it('should return false for invalid links', () => helpers.isValidDockerLink(expectTrue, 'garbage.io/garbage/foo-bar:0.1.1'));
+    it('should return false for invalid links', () => helpers.isValidDockerLink(expectFalse, 'garbage.io/garbage/foo-bar:0.1.1_TESTER_MCTESTER_'));
 });


### PR DESCRIPTION
* fix up backtracking issue that caused api to hang and try to match regex forever
* only match the path between the host and the name once or twice, vs before we were looking forever